### PR TITLE
Print account balance after each trade

### DIFF
--- a/volume_backtester.py
+++ b/volume_backtester.py
@@ -189,6 +189,7 @@ def backtest_volume_breakout(df: pd.DataFrame, params: dict):
                     print(
                         f"    ❌ Stop-loss hit at {exit_time} → -${risk:.2f} (Full SL)"
                     )
+                    print(f"    📊 Account balance after trade: ${balance:.2f}")
                 else:
                     if direction == "long":
                         remainder_profit = (
@@ -210,12 +211,14 @@ def backtest_volume_breakout(df: pd.DataFrame, params: dict):
                         print(
                             f"    🏁 Trailing stop hit at {exit_time}, locking in remaining profit. Trade outcome: Full TP"
                         )
+                        print(f"    📊 Account balance after trade: ${balance:.2f}")
                     else:
                         outcome = "PARTIAL_SL"
                         total_partial += 1
                         print(
                             f"    🟡 Break-even stop hit at {exit_time} after partial. Trade outcome: Partial TP then SL"
                         )
+                        print(f"    📊 Account balance after trade: ${balance:.2f}")
 
                 trade_log.append(
                     {
@@ -309,6 +312,7 @@ def backtest_volume_breakout(df: pd.DataFrame, params: dict):
         print(
             f"    ⚠️ Trade open at end of data. Closing at {final_time} price {final_price:.2f}. Outcome: {outcome}"
         )
+        print(f"    📊 Account balance after trade: ${balance:.2f}")
 
     trade_df = pd.DataFrame(trade_log)
     trade_df.attrs["total_skips"] = total_skips


### PR DESCRIPTION
## Summary
- show the account balance after a position fully closes by a stop or take-profit.

## Testing
- `python - <<'PY'
from volume_backtester import load_data, backtest_volume_breakout

df = load_data('US100.cash_2024.csv').head(500)
params = {
    'lookback': 20,
    'vol_lookback': 20,
    'vol_mult': 2.0,
    'risk': 2000.0,
    'balance': 100000.0,
    'liquidation_level': 90000.0,
}
backtest_volume_breakout(df, params)
PY`


------
https://chatgpt.com/codex/tasks/task_e_68beaed0c3608333bc297a1d0f0983ab