### PR TITLE
Add monthly withdrawal output to summary

### DIFF
--- a/volume_backtester.py
+++ b/volume_backtester.py
@@ -473,9 +473,13 @@ def print_monthly_summary(year, month, balance, account_balance, start_balance, 
     wins = sum(1 for t in trades if t.get("outcome") != "FULL_SL")
     losses = len(trades) - wins
     sign = "+" if pnl >= 0 else "-"
+    period = f"{year}-{month:02d}"
+    withdrawal = WITHDRAWALS_BY_MONTH.get(period, 0.0)
+    withdrawal_str = f" | Withdrawal: ${withdrawal:,.2f}" if withdrawal > 0 else ""
     print(
         f"{year}-{month:02d} | Balance: ${balance:,.2f} | Account: ${account_balance:,.2f} | "
-        f"Trades: {len(trades)} | W:{wins} L:{losses} | P&L: {sign}${abs(pnl):,.2f} | Liquidations: {liquidations}"
+        f"Trades: {len(trades)} | W:{wins} L:{losses} | P&L: {sign}${abs(pnl):,.2f} | "
+        f"Liquidations: {liquidations}{withdrawal_str}"
     )
 
 


### PR DESCRIPTION
## Summary
- Include monthly withdrawal amounts in per-period summaries when present.

## Testing
- `python - <<'PY'
from volume_backtester import print_monthly_summary, WITHDRAWALS_BY_MONTH
WITHDRAWALS_BY_MONTH.clear()
WITHDRAWALS_BY_MONTH['2024-11'] = 1234.56
print_monthly_summary(2024, 11, 260000, 100000, 100000, [], 0)
print_monthly_summary(2024, 12, 295000, 100000, 260000, [], 0)
PY`
- `python volume_backtester.py` *(fails: KeyboardInterrupt, long runtime)*

------
https://chatgpt.com/codex/tasks/task_e_68c172ad0b148333ac48dd45fb161c6f